### PR TITLE
Add RSpec support

### DIFF
--- a/lib/challah/test.rb
+++ b/lib/challah/test.rb
@@ -1,3 +1,10 @@
+require 'challah/test/helpers'
+require 'challah/test/unit'
+
+if defined?(RSpec)
+  require 'challah/test/rspec'
+end
+
 # Used to persist session data in test mode instead of using cookies. Stores the session
 # data lazily in a global var, accessible across the testing environment.
 class TestSessionStore
@@ -25,21 +32,3 @@ end
 
 Challah.options[:storage_class] = TestSessionStore
 
-class ActiveSupport::TestCase
-  # Sign the given user instance in
-  def signin_as(user)
-    Challah::Session.create!(user)
-  end
-  alias_method :login_as, :signin_as
-
-  # Sign the given user instance out
-  def signout
-    Challah::Session.destroy
-  end
-  alias_method :logout, :signout
-
-  setup do
-    # Reset any challah user sessions for each test.
-    $challah_test_session = nil
-  end
-end

--- a/lib/challah/test/helpers.rb
+++ b/lib/challah/test/helpers.rb
@@ -1,0 +1,19 @@
+module Challah
+  module Test
+    module Helpers
+      # Sign the given user instance in
+      def signin_as(user)
+        Challah::Session.create!(user)
+      end
+      alias_method :login_as, :signin_as
+
+      # Sign the given user instance out
+      def signout
+        Challah::Session.destroy
+      end
+      alias_method :logout, :signout
+    end
+  end
+end
+
+

--- a/lib/challah/test/rspec.rb
+++ b/lib/challah/test/rspec.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.include Challah::Test::Helpers
+
+  config.before(:each) do
+    # Reset any challah user sessions for each test.
+    $challah_test_session = nil
+  end
+end

--- a/lib/challah/test/unit.rb
+++ b/lib/challah/test/unit.rb
@@ -1,0 +1,8 @@
+class ActiveSupport::TestCase
+  include Challah::Test::Helpers
+
+  setup do
+    # Reset any challah user sessions for each test.
+    $challah_test_session = nil
+  end
+end


### PR DESCRIPTION
Not ready for merge. Adds configuration to allow the helpers to be used in RSpec. Separates into a few files:

```
lib/challah/test/helpers  # The helper methods
lib/challah/test/unit     # Test::Unit integrations
lib/challah/test/rspec    # RSpec integrations
```

One thing that stands out as odd to me is [this bit](https://github.com/philtr/challah/blob/1bc3deb5001ce5aa1c39258a881b1b8e02e302ae/lib/challah/test.rb#L4-L6):

``` ruby
if defined?(RSpec)
  require 'challah/test/rspec'
end
```

But alas, this is how thoughtbot [does it with shoulda](https://github.com/thoughtbot/shoulda-matchers/blob/master/lib/shoulda/matchers.rb#L4-L6). If you can think of a better way I'm open to ideas.

By the way, all the current tests pass, but I am at a bit of a loss as for where to start testing the RSpec stuff. Maybe I will look at `shoulda-matchers` and see how they do it.

I'd love to hear your feedback on this feature.
