### PR TITLE
Allow for case-insensitive finding of user by username/email

### DIFF
--- a/lib/challah/concerns/user/findable.rb
+++ b/lib/challah/concerns/user/findable.rb
@@ -14,31 +14,29 @@ module Challah
       # Find a user instance by username first, or email address if needed.
       # If no user is found matching, return nil
       def find_for_session(username_or_email)
-        return nil if username_or_email.to_s.blank?
+        return if username_or_email.to_s.blank?
 
-        result = nil
-
-        if username_or_email.to_s.include?('@')
-          result = where(email: username_or_email).first
-        end
-
-        if !result
-          uid = username_or_email.to_s.downcase.strip
-
-          authorization = self.authorization_model
-          authorization = authorization.where(provider: :password, uid: uid)
-          authorization = authorization.first
-
-          if authorization
-            result = authorization.user
-          end
-        end
-
-        result
+        username_or_email = username_or_email.downcase.strip
+        find_by_email(username_or_email) || find_by_authorization(username_or_email)
       end
 
       def inactive
         where.not(active: true)
+      end
+
+      protected
+
+      def find_by_authorization(uid)
+        authorization = self.authorization_model
+        result = authorization.where(provider: :password, uid: uid).first
+        if result
+          result.user
+        end
+      end
+
+      def find_by_email(email)
+        return unless email.include?('@')
+        where(email: email).first
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,8 +13,8 @@ module Challah
       user_one.save
       user_two.save
 
-      assert_equal user_one, User.find_for_session('test-user')
-      assert_equal user_one, User.find_for_session('tester@example.com')
+      assert_equal user_one, User.find_for_session('test-user   ')
+      assert_equal user_one, User.find_for_session('tester@example.com   ')
 
       assert_equal user_one, User.find_for_session('Test-user')
       assert_equal user_one, User.find_for_session('tester@example.com')
@@ -24,6 +24,16 @@ module Challah
 
       assert_equal nil, User.find_for_session(' ')
       assert_equal nil, User.find_for_session('not-existing')
+      assert_equal nil, User.find_for_session(nil)
+    end
+
+    it "should find by username or email regardless of case" do
+      user = build(:user, :username => 'test-user', :email => 'tester@example.com')
+      user.password!('test123')
+      user.save
+
+      assert_equal user, User.find_for_session('TEST-user')
+      assert_equal user, User.find_for_session('TESTER@example.com')
     end
 
     it "should have a reference to the authorizations model" do


### PR DESCRIPTION
Allow `User.find_for_session` to intake case insensitive data.

Also, a little cleanup - there was some unnecessary duplication.
