### PR TITLE
Normalize email before validation

### DIFF
--- a/lib/challah/concerns/user/attributeable.rb
+++ b/lib/challah/concerns/user/attributeable.rb
@@ -8,6 +8,7 @@ module Challah
       attr_reader :password_updated
 
       before_save :ensure_user_tokens
+      before_validation :normalize_user_email
     end
 
     # Returns true if this user is active, and should be able to log in. If
@@ -69,5 +70,10 @@ module Challah
       end
     end
 
+    # Downcase email and strip if of whitespace
+    # Ex: "   HELLO@example.com   " => "hello@example.com"
+    def normalize_user_email
+      self.email = self.email.to_s.downcase.strip
+    end
   end
 end

--- a/lib/challah/version.rb
+++ b/lib/challah/version.rb
@@ -1,3 +1,3 @@
 module Challah
-  VERSION = "1.2.5" unless defined?(::Challah::VERSION)
+  VERSION = "1.2.6" unless defined?(::Challah::VERSION)
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,12 @@ require "spec_helper"
 module Challah
   # TODO make these specs not look like unit tests
   describe User do
+    it "should normalize the user's email" do
+      user = build(:user, email: "  YELLING@example.com  ")
+      user.save
+      expect(user.email).to eq "yelling@example.com"
+    end
+
     it "should find a user by username or email" do
       user_one = build(:user, :username => ' Test-user ', :email => 'tester@example.com')
       user_two = build(:user, :username => 'test-user-2  ', :email => 'tester2@example.com')


### PR DESCRIPTION
We've had trouble with other apps where users create accounts with emails of differing cases.

Then, when finding those accounts - if it's saved as "HELLO@example.com", and we search for "hello@example.com" => we won't find the user.

Plus, if we allow for multiple cases, and we're validating on email uniqueness, then there can be multiple accounts of the same email - which creates a problem when we strive to go back and fix the underlying search issue after the app has been in production.