### PR TITLE
Allow Email parameter for Session management

### DIFF
--- a/lib/challah/session.rb
+++ b/lib/challah/session.rb
@@ -74,7 +74,11 @@ module Challah
     end
 
     def username
-      params[:username] || ""
+      params[:username] || params[:email] || ""
+    end
+
+    def username?
+      !username.empty?
     end
 
     # Returns true if this session has been authenticated and is ready to save.

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "./spec/dummy/app/controllers/application_controller"
 
 module Challah
   describe SessionsController do


### PR DESCRIPTION
Allow passing of email address as parameter

Generally, when creating a session that uses `email` and `password`, you either have to specify the
`email` attribute on the form as being `:username`:

```ruby
= form.email_field :username
```

or adjust the params in the controller to explicitly assign the
`email` param to be `username`.

```ruby
def session_params
  {
    username: params[:session][:email],
    password: params[:session][:password],
  }
end
```

But when validating an account in the guts of Challah, `username` and `email` are [used interchangeably](https://github.com/jdtornow/challah/blob/master/lib/challah/concerns/user/findable.rb#L16).

This addition allows for someone to pass in `email` as a session param as an alternative to `username`.
