### PR TITLE
Save user ID as GlobalID in the session

### DIFF
--- a/lib/challah/session.rb
+++ b/lib/challah/session.rb
@@ -106,7 +106,11 @@ module Challah
     def self.create(user_or_user_id, request = nil, params = nil, user_model = nil)
       user_model = Challah.user if user_model.nil?
 
-      user_record = user_model === user_or_user_id ? user_or_user_id : user_model.find_by_id(user_or_user_id)
+      user_record = if user_model === user_or_user_id
+        user_or_user_id
+      else
+        GlobalID::Locator.locate user_or_user_id
+      end
 
       session = Session.new(request, params, user_model)
 

--- a/lib/challah/session.rb
+++ b/lib/challah/session.rb
@@ -45,7 +45,7 @@ module Challah
       persistence_token, user_id = self.store.read
       return false if persistence_token.nil? or user_id.nil?
 
-      store_user = user_model.unscoped.where(id: user_id).first
+      store_user = GlobalID::Locator.locate(user_id)
 
       if store_user and store_user.active? and store_user.persistence_token == persistence_token
         if store_user.valid_session?
@@ -70,7 +70,7 @@ module Challah
 
     # Id of the current user.
     def user_id
-      @user_id ||= self.user ? self.user[:id] : nil
+      @user_id ||= self.user ? self.user.to_global_id : nil
     end
 
     def username

--- a/lib/challah/session.rb
+++ b/lib/challah/session.rb
@@ -146,7 +146,7 @@ module Challah
     protected
 
     # Try and authenticate against the various auth techniques. If one
-    # technique works, then just exist and make the session active.
+    # technique works, then just exit and make the session active.
     def authenticate!
       Challah.techniques.values.each do |klass|
         technique = klass.new(self)

--- a/lib/challah/test.rb
+++ b/lib/challah/test.rb
@@ -12,14 +12,14 @@ module Challah
 
     def read
       if $challah_test_session
-        return $challah_test_session.to_s.split(":")
+        return $challah_test_session.to_s.split("@")
       end
 
       nil
     end
 
     def save(token, user_id)
-      $challah_test_session = "#{ token }:#{ user_id }"
+      $challah_test_session = "#{ token }@#{ user_id }"
       true
     end
   end

--- a/spec/lib/cookie_store_spec.rb
+++ b/spec/lib/cookie_store_spec.rb
@@ -17,10 +17,10 @@ module Challah
       session.save
 
       assert_equal %w( challah-s challah-v ), request.cookies.keys.sort
-      assert_equal "#{user.persistence_token}@#{user.id}", request.cookies['challah-s'][:value]
+      assert_equal "#{user.persistence_token}@#{user.to_global_id}", request.cookies['challah-s'][:value]
       assert_equal "test.dev", request.cookies['challah-s'][:domain]
 
-      assert_equal Encrypter.md5("#{user.persistence_token}@#{user.id}", request.user_agent, request.remote_ip), request.cookies['challah-v'][:value]
+      assert_equal Encrypter.md5("#{user.persistence_token}@#{user.to_global_id}", request.user_agent, request.remote_ip), request.cookies['challah-v'][:value]
       assert_equal "test.dev", request.cookies['challah-v'][:domain]
     end
 
@@ -43,8 +43,8 @@ module Challah
       session.user = user
       session.save
 
-      validation_cookie_val = Encrypter.md5("#{user.persistence_token}@#{user.id}", request.user_agent, request.remote_ip)
-      session_cookie_val = "#{user.persistence_token}@#{user.id}"
+      validation_cookie_val = Encrypter.md5("#{user.persistence_token}@#{user.to_global_id}", request.user_agent, request.remote_ip)
+      session_cookie_val = "#{user.persistence_token}@#{user.to_global_id}"
 
       assert_equal session_cookie_val, request.cookies['challah-s'][:value]
       assert_equal session_cookie_val, session.store.send(:session_cookie)[:value]
@@ -61,7 +61,7 @@ module Challah
 
       assert_equal true, session2.store.send(:existing?)
       assert_equal true, session2.valid?
-      assert_equal user.id, session2.user_id
+      assert_equal user.to_global_id, session2.user_id
 
       allow(session.store).to receive(:validation_cookie).and_return('bad-value')
 

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -72,7 +72,7 @@ module Challah
 
       session = Session.create(user)
       assert_equal true, session.valid?
-      assert_equal user.id, session.user_id
+      assert_equal user.to_global_id, session.user_id
     end
 
     it "should create a blank but invalid session for a non-existant or inactive user" do
@@ -190,7 +190,7 @@ module Challah
       expect { session.valid? }.to change { user.session_count }.by(1)
 
       assert_equal user, session.user
-      assert_equal user.id, session.user_id
+      assert_equal user.to_global_id, session.user_id
       assert_equal true, session.persist?
       assert_equal true, session.save
     end
@@ -209,7 +209,7 @@ module Challah
       expect { session.valid? }.to_not change { user.session_count }
 
       assert_equal user, session.user
-      assert_equal user.id, session.user_id
+      assert_equal user.to_global_id, session.user_id
       assert_equal false, session.persist?
       assert_equal false, session.save
 
@@ -248,7 +248,7 @@ module Challah
       expect { session.valid? }.to change { user.session_count }.by(1)
 
       assert_equal user, session.user
-      assert_equal user.id, session.user_id
+      assert_equal user.to_global_id, session.user_id
       assert_equal true, session.persist?
       assert_equal true, session.save
     end

--- a/spec/lib/simple_cookie_store_spec.rb
+++ b/spec/lib/simple_cookie_store_spec.rb
@@ -23,10 +23,10 @@ module Challah
       session.save
 
       assert_equal %w( challah-s challah-v ), request.cookies.keys.sort
-      assert_equal "#{user.persistence_token}@#{user.id}", request.cookies['challah-s'][:value]
+      assert_equal "#{user.persistence_token}@#{user.to_global_id}", request.cookies['challah-s'][:value]
       assert_equal "test.dev", request.cookies['challah-s'][:domain]
 
-      assert_equal Encrypter.md5("#{user.persistence_token}@#{user.id}"), request.cookies['challah-v'][:value]
+      assert_equal Encrypter.md5("#{user.persistence_token}@#{user.to_global_id}"), request.cookies['challah-v'][:value]
       assert_equal "test.dev", request.cookies['challah-v'][:domain]
     end
 
@@ -40,10 +40,10 @@ module Challah
       session.save
 
       assert_equal %w( challah-d635fd-s challah-d635fd-v ), request.cookies.keys.sort
-      assert_equal "#{user.persistence_token}@#{user.id}", request.cookies['challah-d635fd-s'][:value]
+      assert_equal "#{user.persistence_token}@#{user.to_global_id}", request.cookies['challah-d635fd-s'][:value]
       assert_equal "test.dev", request.cookies['challah-d635fd-s'][:domain]
 
-      assert_equal Encrypter.md5("#{user.persistence_token}@#{user.id}"), request.cookies['challah-d635fd-v'][:value]
+      assert_equal Encrypter.md5("#{user.persistence_token}@#{user.to_global_id}"), request.cookies['challah-d635fd-v'][:value]
       assert_equal "test.dev", request.cookies['challah-d635fd-v'][:domain]
     end
 
@@ -66,8 +66,8 @@ module Challah
       session.user = user
       session.save
 
-      validation_cookie_val = Encrypter.md5("#{user.persistence_token}@#{user.id}")
-      session_cookie_val = "#{user.persistence_token}@#{user.id}"
+      validation_cookie_val = Encrypter.md5("#{user.persistence_token}@#{user.to_global_id}")
+      session_cookie_val = "#{user.persistence_token}@#{user.to_global_id}"
 
       assert_equal session_cookie_val, request.cookies['challah-s'][:value]
       assert_equal session_cookie_val, session.store.send(:session_cookie)[:value]
@@ -84,7 +84,7 @@ module Challah
 
       assert_equal true, session2.store.send(:existing?)
       assert_equal true, session2.valid?
-      assert_equal user.id, session2.user_id
+      assert_equal user.to_global_id, session2.user_id
 
       allow(session.store).to receive(:validation_cookie).and_return('bad-value')
 


### PR DESCRIPTION
We had a need to have several user models use the same admin interface. This allows for it by saving the user as a GlobalID in the user session instead of an integer.

I put some conditionals in to keep backwards compatibility for Rails < 4.2. If that is not a priority, I'd be happy to remove them. :smile: