### PR TITLE
Drop support for Rails < 4.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,5 @@ script: bundle exec rspec
 cache: bundler
 gemfile:
   - Gemfile
-  - gemfiles/rails40.gemfile
-  - gemfiles/rails41.gemfile
   - gemfiles/rails42.gemfile
   - gemfiles/rails5beta.gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     challah (1.2.11)
       bcrypt (~> 3.1)
       highline (~> 1.7, >= 1.7.1)
-      rails (>= 4.0.0)
+      rails (>= 4.2.0)
       rake (~> 10.3)
 
 GEM
@@ -159,4 +159,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,12 +1,6 @@
 if defined?(ApplicationController)
   class SessionsController < ApplicationController
-    if respond_to?(:before_action)
-      # Rails >= 4.0
-      before_action :destroy_session, except: :create
-    else
-      # Rails <= 3.2
-      before_filter :destroy_session, except: :create
-    end
+    before_action :destroy_session, except: :create
 
     unloadable
 

--- a/challah.gemspec
+++ b/challah.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "highline", "~> 1.7", ">= 1.7.1"
-  s.add_dependency "rails", ">= 4.0.0"
+  s.add_dependency "rails", ">= 4.2.0"
   s.add_dependency "rake", "~> 10.3"
   s.add_dependency "bcrypt", "~> 3.1"
 

--- a/lib/challah/controller.rb
+++ b/lib/challah/controller.rb
@@ -29,14 +29,8 @@ module Challah
       #
       # @see Controller::InstanceMethods#signin_required signin_required
       def restrict_to_authenticated(options = {})
-        block = proc { |controller| controller.send(:signin_required) }
-
-        if respond_to?(:before_action)
-          # Rails >= 4.0
-          before_action(options, &block)
-        else
-          # Rails <= 3.2
-          before_filter(options, &block)
+        before_action(options) do |controller|
+          controller.send(:signin_required)
         end
       end
 


### PR DESCRIPTION
These are the only backwards compatibility hacks I'm aware of, let me know if there are more and I'll remove those as well.