### PR TITLE
Fix Rails 4.2 "can't modify frozen hash ActiveSupport::HashWithIndifferentAccess"

### DIFF
--- a/lib/challah/audit.rb
+++ b/lib/challah/audit.rb
@@ -96,7 +96,7 @@ module Challah
           write_attribute(attribute_name, nil)
         end
 
-        changed_attributes.delete(attribute_name)
+        @changed_attributes.delete(attribute_name)
       end
     end
   end

--- a/spec/lib/audit_spec.rb
+++ b/spec/lib/audit_spec.rb
@@ -17,13 +17,14 @@ module Challah
 
       include Challah::Audit
 
-      attr_accessor :name, :created_by, :created_at, :updated_by, :updated_at
+      attr_accessor :name, :created_by, :created_at, :updated_by, :updated_at, :changed_attributes
 
       def initialize(attributes = {})
         attributes.each do |name, value|
           send("#{name}=", value)
         end
 
+        @changed_attributes = {}
         @attributes = {}
       end
 
@@ -50,11 +51,6 @@ module Challah
 
       def write_attribute(attr_name, value)
         self.send("#{attr_name}=", value)
-      end
-
-      # Stub for tests
-      def changed_attributes
-        {}
       end
 
       # Stubs
@@ -104,6 +100,12 @@ module Challah
 
       assert_equal nil, @model.created_by
       assert_equal nil, @model.updated_by
+    end
+
+    describe "with an real model subclass" do
+      it "should not raise an error if nothing has changed" do
+        expect { User.new.send(:initialize_dup, nil) }.to_not raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Looks like in rails 4.2, the `changed_attributes` method returns a frozen hash when no attributes have changed, which raises an error when we try to delete keys from it.

Looks like other libraries have used the internal instance variable directly (https://github.com/mbleigh/acts-as-taggable-on/pull/583) to access the mutable copy.

Our tests didn't catch it because the audit spec is based on a stubbed class. To add in a quick safe-guard, I added a spec that runs the audit against our built in `User` model. Since the `Audit` module is available to all of ActiveRecord, it gets tested indirectly.

**Test Case:**
```rb
describe "with an real model subclass" do
  it "should not raise an error if nothing has changed" do
    expect { User.new.send(:initialize_dup, nil) }.to_not raise_error
  end
end
```
```
1) Challah::Audit with an real model subclass should not raise an error if nothing has changed
   Failure/Error: expect { stub.send(:initialize_dup, nil) }.to_not raise_error
   
     expected no Exception, got #<RuntimeError: can't modify frozen ActiveSupport::HashWithIndifferentAccess> with backtrace:
       # ./lib/challah/audit.rb:99:in `block in clear_audit_attributes'
       # ./lib/challah/audit.rb:94:in `each'
       # ./lib/challah/audit.rb:94:in `clear_audit_attributes'
       # ./lib/challah/audit.rb:39:in `initialize_dup'
       # ./spec/lib/audit_spec.rb:109:in `block (4 levels) in <module:Challah>'
       # ./spec/lib/audit_spec.rb:109:in `block (3 levels) in <module:Challah>'
   # ./spec/lib/audit_spec.rb:109:in `block (3 levels) in <module:Challah>'
```