### PR TITLE
Fix running migrations on empty database

### DIFF
--- a/lib/challah/concerns/user/attributeable.rb
+++ b/lib/challah/concerns/user/attributeable.rb
@@ -7,8 +7,13 @@ module Challah
       attr_reader :password_confirmation
       attr_reader :password_updated
 
-      if columns.map(&:name).include?("status")
-        enum status: %w( active inactive )
+      begin
+        if columns.map(&:name).include?("status")
+          enum status: %w( active inactive )
+        end
+      rescue ActiveRecord::StatementInvalid => exception
+        raise exception unless exception.message =~ /could not find table/i ||
+                               exception.message =~ /does not exist/i
       end
 
       before_save :ensure_user_tokens

--- a/spec/lib/attributeable_spec.rb
+++ b/spec/lib/attributeable_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+module Challah
+  describe UserAttributeable do
+    it "doesn't raise an error if the table doesn't exist yet" do
+      expect {
+        class OtherUser < ActiveRecord::Base
+          include Challah::Userable
+          @table_name = "other_users"
+        end
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Good afternoon @jdtornow!

I couldn't run migrations on an empty database in Rails 5.

Running `rails db:migrate` gave me this error:

```
ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "admin_users" does not exist
LINE 8:                WHERE a.attrelid = '"admin_users"'::regclass
                                          ^
:               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
             (SELECT c.collname FROM pg_collation c, pg_type t
               WHERE c.oid = a.attcollation AND t.oid = a.atttypid AND a.attcollation <> t.typcollation),
                     col_description(a.attrelid, a.attnum) AS comment
                FROM pg_attribute a LEFT JOIN pg_attrdef d
                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
               WHERE a.attrelid = '"admin_users"'::regclass
                 AND a.attnum > 0 AND NOT a.attisdropped
               ORDER BY a.attnum
```

Commenting out `include Challah::Userable` fixed the issue, as well as the code attached to this pull request (`does not exist` is for postgres, `could not find table` is for sqlite).

I'm not married to this approach, but this was the offending code. If you have a better idea, I'd be happy to implement it.

Cheers!