### PR TITLE
Extract status enum to separate concern

### DIFF
--- a/lib/challah.rb
+++ b/lib/challah.rb
@@ -32,6 +32,7 @@ module Challah
   autoload :UserFindable,                     "challah/concerns/user/findable"
   autoload :UserPasswordable,                 "challah/concerns/user/passwordable"
   autoload :UserProvideable,                  "challah/concerns/user/provideable"
+  autoload :UserStatusable,                   "challah/concerns/user/statusable"
   autoload :UserValidateable,                 "challah/concerns/user/validateable"
 
   # Configuration options

--- a/lib/challah/concerns/user/attributeable.rb
+++ b/lib/challah/concerns/user/attributeable.rb
@@ -7,39 +7,9 @@ module Challah
       attr_reader :password_confirmation
       attr_reader :password_updated
 
-      begin
-        if columns.map(&:name).include?("status")
-          enum status: %w( active inactive )
-        end
-      rescue ActiveRecord::StatementInvalid => exception
-        raise exception unless exception.message =~ /could not find table/i ||
-                               exception.message =~ /does not exist/i
-      end
-
       before_save :ensure_user_tokens
       before_validation :normalize_user_email
     end
-
-    # Fallback to pre-enum active column (pre challah 1.4)
-    def active=(enabled)
-      if self.class.columns.map(&:name).include?("status")
-        self.status = (!!enabled ? :active : :inactive)
-      else
-        write_attribute(:active, !!enabled)
-      end
-    end
-
-    def active?
-      # enum-based status
-      if self.class.columns.map(&:name).include?("status")
-        read_attribute(:status).to_s == "active"
-
-      # support for non-enum status column (pre challah 1.4)
-      else
-        !!read_attribute(:active)
-      end
-    end
-    alias_method :active, :active?
 
     # First name and last name together
     def name
@@ -55,7 +25,7 @@ module Challah
     #
     # Override this method if you need to check for a particular configuration on each page request.
     def valid_session?
-      active?
+      true
     end
 
     protected

--- a/lib/challah/concerns/user/statusable.rb
+++ b/lib/challah/concerns/user/statusable.rb
@@ -1,0 +1,41 @@
+module Challah
+  module UserStatusable
+    extend ActiveSupport::Concern
+
+    included do
+      begin
+        if columns.map(&:name).include?("status")
+          enum status: %w( active inactive )
+        end
+      rescue ActiveRecord::StatementInvalid => exception
+        raise exception unless exception.message =~ /could not find table/i ||
+                               exception.message =~ /does not exist/i
+      end
+    end
+
+    # Fallback to pre-enum active column (pre challah 1.4)
+    def active=(enabled)
+      if self.class.columns.map(&:name).include?("status")
+        self.status = (!!enabled ? :active : :inactive)
+      else
+        write_attribute(:active, !!enabled)
+      end
+    end
+
+    def active?
+      # enum-based status
+      if self.class.columns.map(&:name).include?("status")
+        read_attribute(:status).to_s == "active"
+
+      # support for non-enum status column (pre challah 1.4)
+      else
+        !!read_attribute(:active)
+      end
+    end
+    alias_method :active, :active?
+
+    def valid_session?
+      active?
+    end
+  end
+end

--- a/lib/challah/concerns/user/statusable.rb
+++ b/lib/challah/concerns/user/statusable.rb
@@ -5,7 +5,8 @@ module Challah
     included do
       begin
         if columns.map(&:name).include?("status")
-          enum status: %w( active inactive )
+          additional_statuses = Array(Challah.options[:additional_statuses])
+          enum status: [:active, :inactive, *additional_statuses]
         end
       rescue ActiveRecord::StatementInvalid => exception
         raise exception unless exception.message =~ /could not find table/i ||

--- a/lib/challah/concerns/userable.rb
+++ b/lib/challah/concerns/userable.rb
@@ -9,6 +9,10 @@ module Challah
     include UserPasswordable
     include UserProvideable
 
+    unless Challah.options[:skip_status_enum]
+      include UserStatusable
+    end
+
     unless Challah.options[:skip_user_validations]
       include UserValidateable
     end

--- a/lib/challah/concerns/userable.rb
+++ b/lib/challah/concerns/userable.rb
@@ -8,10 +8,7 @@ module Challah
     include UserFindable
     include UserPasswordable
     include UserProvideable
-
-    unless Challah.options[:skip_status_enum]
-      include UserStatusable
-    end
+    include UserStatusable
 
     unless Challah.options[:skip_user_validations]
       include UserValidateable

--- a/lib/challah/session.rb
+++ b/lib/challah/session.rb
@@ -53,7 +53,7 @@ module Challah
         nil
       end
 
-      if store_user and store_user.active? and store_user.persistence_token == persistence_token
+      if store_user and store_user.valid_session? and store_user.persistence_token == persistence_token
         if store_user.valid_session?
           self.user = store_user
           @valid = true
@@ -90,7 +90,7 @@ module Challah
     # Returns true if this session has been authenticated and is ready to save.
     def valid?
       return @valid if @valid != nil
-      return true if self.user and self.user.active?
+      return true if self.user and self.user.valid_session?
       authenticate!
     end
 
@@ -126,7 +126,7 @@ module Challah
         end
       end
 
-      if user_record and user_record.active?
+      if user_record and user_record.valid_session?
         session.user = user_record
         session.persist = true
       end

--- a/lib/challah/techniques/api_key_technique.rb
+++ b/lib/challah/techniques/api_key_technique.rb
@@ -16,7 +16,7 @@ module Challah
       unless @key.to_s.blank?
         user = user_model.find_by_api_key(@key)
 
-        if user and user.active?
+        if user and user.valid_session?
           return user
         end
       end

--- a/lib/challah/techniques/password_technique.rb
+++ b/lib/challah/techniques/password_technique.rb
@@ -17,7 +17,7 @@ module Challah
         user = user_model.find_for_session(username)
 
         if user
-          if user.active?
+          if user.valid_session?
             if user.authenticate(@password)
               return user
             end

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -12,14 +12,14 @@ module Challah
         999
       end
 
-      def active?
+      def valid_session?
         true
       end
 
     end
 
     describe "#inspect" do
-      let(:session) { session = Session.create(user) }
+      let(:session) { Session.create(user) }
 
       it "has a pretty inspection" do
         expect(session.inspect).to match(/#<Session/)


### PR DESCRIPTION
I wanted to be able to add another item to the `status` enum ("pending"), but it doesn't look like Rails provides a way to do that once you've already defined an enum. This moves all the enum-related logic to a separate concern for the user model that can be toggled with an option.

An alternate solution would be something like this:

```ruby
# We could set the statuses in the initializer
Challah.options[:statuses] = { pending: 0, active: 1, inactive: 2 }

# Or only set the additional new ones
Challah.options[:additional_statuses] = [:pending]
```

Thoughts?